### PR TITLE
Upgrade OrderedProperties dependency for Java11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation gradleApi()
     implementation localGroovy()
-    implementation 'nu.studer:java-ordered-properties:1.0.1'
+    implementation 'nu.studer:java-ordered-properties:1.0.2'
 
     testImplementation gradleTestKit()
     testImplementation group: 'junit', name: 'junit', version: '4.12'
@@ -39,7 +39,7 @@ ext {
 
     // Library Repository
     libraryName = 'GrabVer'
-    libraryVersion = '2.0.1'
+    libraryVersion = '2.0.2'
     displayName = 'Gradle Automatic Build Versioning Plugin'
     libraryDescription = 'An easy Gradle plugin that follows semver.org rules to automatically generate the Patch version, Build number and Code version, while Major, Minor and Pre-Release suffix remain under our control.'
     libraryLabels = ['semver', 'version', 'versioning', 'build-versioning', 'automatic-versioning', 'intellij-idea', 'android-studio', 'auto-reset']

--- a/src/main/groovy/eu/davidea/gradle/GrabVer.groovy
+++ b/src/main/groovy/eu/davidea/gradle/GrabVer.groovy
@@ -49,7 +49,7 @@ import static eu.davidea.gradle.ConsoleColors.*
  */
 class GrabVer implements Plugin<Project> {
 
-    private static String GRABVER_VERSION = "2.0.1"
+    private static String GRABVER_VERSION = "2.0.2"
     private static String[] RELEASE_TASKS = ["assembleRelease", "bundleRelease", "grabverRelease"]
     private static String[] SAVE_TASKS = ["build", "assembleDebug", "assembleRelease", "bundleDebug", "bundleRelease", "grabverRelease", "jar", "war", "explodedWar"]
 


### PR DESCRIPTION
The 'version.properties' file was not being populated anymore when the project was using Java11. The OrderedProperty dependency has been upgraded for this, so upgrading it will fix the problem.

https://github.com/etiennestuder/java-ordered-properties/releases/tag/v1.0.2

